### PR TITLE
chore(CI): add module to the cache preparation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ jobs:
       before_install:
         - cd ..
         - git clone --depth=1 --branch=master https://github.com/azerothcore/azerothcore-wotlk.git azerothcore-wotlk
+        - mv "$TRAVIS_BUILD_DIR" azerothcore-wotlk/modules
         - cd azerothcore-wotlk
         - source ./apps/ci/ci-before_install.sh
       install:
@@ -54,6 +55,7 @@ jobs:
       before_install:
         - cd ..
         - git clone --depth=1 --branch=master https://github.com/azerothcore/azerothcore-wotlk.git azerothcore-wotlk
+        - mv "$TRAVIS_BUILD_DIR" azerothcore-wotlk/modules
         - cd azerothcore-wotlk
         - source ./apps/ci/ci-before_install.sh
       install:


### PR DESCRIPTION
Add the module to the cache preparation. Although this is not necessary for most of the modules it is at least necessary for the eluna module. This PR is just about harmonizing the Travis configuration for all modules.