### PR TITLE
feat(CI) Allow manual workflow triggering.

### DIFF
--- a/.github/workflows/core-build.yml
+++ b/.github/workflows/core-build.yml
@@ -2,6 +2,7 @@ name: core-build
 on:
   push:
   pull_request:
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
It would be nice to be able to re-run a workflow from the Github actions tab if it fails for a reason unrelated to the module.
This avoids needing to push or pull to re-run the action.

https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch